### PR TITLE
Refactored normalize for champions

### DIFF
--- a/lib/riot-lol.js
+++ b/lib/riot-lol.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { CDN_URL, LATEST_PATCH, DEFAULT_LANG, ITEMS_MAP } from "./enums";
-import { normalize, normalizeItem } from "./utils";
+import { normalize, normalizeChampion, normalizeItem } from "./utils";
 
 class RiotLoL {
   constructor() {
@@ -27,7 +27,7 @@ class RiotLoL {
       let championsMap = response.data.data;
 
       return Object.keys(championsMap).map(name =>
-        normalize(championsMap[name], this.imageCdnUrl)
+        normalizeChampion(championsMap[name], this.imageCdnUrl)
       );
     } catch (err) {
       throw err;
@@ -40,7 +40,7 @@ class RiotLoL {
         method: "get",
         url: `${this.dataCdnUrl}/champion/${champion}.json`
       });
-      return normalize(response.data.data[champion], this.imageCdnUrl);
+      return normalizeChampion(response.data.data[champion], this.imageCdnUrl);
     } catch (err) {
       throw err;
     }

--- a/lib/riot-lol.js
+++ b/lib/riot-lol.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { CDN_URL, LATEST_PATCH, DEFAULT_LANG, ITEMS_MAP } from "./enums";
-import { normalize, normalizeChampion, normalizeItem } from "./utils";
+import { normalizeChampion, normalizeItem } from "./utils";
 
 class RiotLoL {
   constructor() {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-export const normalize = (champion, imageCdnUrl) => {
+export const normalizeChampion = (champion, imageCdnUrl) => {
   champion.spriteCss = {
     "background-image": `url('${imageCdnUrl}/sprite/${champion.image.sprite}')`,
     "background-position": `${champion.image.x * -1}px ${champion.image.y *
@@ -13,10 +13,6 @@ export const normalize = (champion, imageCdnUrl) => {
   delete champion.version;
 
   return champion;
-};
-
-export const normalizeChampion = (champion, imageCdnUrl) => {
-  return normalize(champion, imageCdnUrl);
 };
 
 export const normalizeItem = (item, itemId) => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,6 +15,10 @@ export const normalize = (champion, imageCdnUrl) => {
   return champion;
 };
 
+export const normalizeChampion = (champion, imageCdnUrl) => {
+  return normalize(champion, imageCdnUrl);
+};
+
 export const normalizeItem = (item, itemId) => {
   item.id = itemId;
   delete item.colloq;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riot-lol",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Library for Riot's League of Legends Static CDN Data",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Renamed the `normalize` function to `normalizeChampion`, but kept the former for backwards compatibility.